### PR TITLE
#FEAT : 로그인 유지 기능 추가, 방문신청 해당주소 자동 폼 입력, 데이터 캐싱관리

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,17 @@
 import Router from "./shared/Router";
 import GlobalStyle from "./utils/styles/GlobalStyle";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { ReactQueryDevtools } from "react-query/devtools";
 import { Provider } from "react-redux";
 import store from "./redux/config/ConfigStore";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -12,6 +19,7 @@ function App() {
         <GlobalStyle />
         <Router />
       </Provider>
+      <ReactQueryDevtools initialIsOpen={true} />
     </QueryClientProvider>
   );
 }

--- a/src/components/AdminApproveList.jsx
+++ b/src/components/AdminApproveList.jsx
@@ -41,6 +41,7 @@ export default function AdminApproveList() {
     },
     {
       keepPreviousData: true,
+      cacheTime: 0,
     }
   );
 
@@ -57,14 +58,12 @@ export default function AdminApproveList() {
   });
 
   const HandlerApprove = (row) => {
-    console.log("승인 누름", row.original.id);
     adminModifyMutation.mutate({
       id: row.original.id,
       status: "2",
     });
   };
   const HandlerReject = (row) => {
-    console.log("거절 누름", row.original.id);
     adminModifyMutation.mutate({
       id: row.original.id,
       status: "3",

--- a/src/components/GuestMyPageTable.jsx
+++ b/src/components/GuestMyPageTable.jsx
@@ -37,7 +37,11 @@ export default function GuestMyPageTable() {
       return guestVisit(queryParams);
     },
     {
+      //query key가 변경되어도 새 데이터가 요청되는 동안 마지막 성공fetch data로 유지
+      //이후 query 요청이 성공시에 새로운값으로 변경.
       keepPreviousData: true,
+      //캐싱타임을 0으로 줘서 필터링시에 쓸데없는 캐싱을 하지않고 새로운 데이터를 요청하게함.
+      cacheTime: 0,
     }
   );
 

--- a/src/components/loginForm/AdminLoginForm.jsx
+++ b/src/components/loginForm/AdminLoginForm.jsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 import { setCookie } from "../../api/cookies";
 import { makeStyles } from "@mui/styles";
 import arrow from "../../utils/img/arrow_icon.png";
+import { useSelector } from "react-redux";
 
 //mui custom css
 const useStyles = makeStyles({
@@ -27,6 +28,7 @@ const useStyles = makeStyles({
 
 export default function AdminLoginForm() {
   const navigate = useNavigate();
+  const { menu } = useSelector((state) => state.LoginMenuSlice);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const classes = useStyles();
@@ -39,6 +41,7 @@ export default function AdminLoginForm() {
         data.headers.refreshtoken.split(" ")[1]
       );
       localStorage.setItem("name", data.data.data.name);
+      localStorage.setItem("usertype", menu);
 
       navigate("/admin/main");
     },

--- a/src/components/loginForm/GuestLoginForm.jsx
+++ b/src/components/loginForm/GuestLoginForm.jsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import { TextField, Button, Link, Grid } from "@mui/material";
 import styled, { keyframes } from "styled-components";
 import { useMutation } from "react-query";
+import { useSelector } from "react-redux";
+
 import { loginguest } from "../../api/api";
 import { useNavigate } from "react-router-dom";
 import { setCookie } from "../../api/cookies";
@@ -28,6 +30,7 @@ const useStyles = makeStyles({
 
 export default function GuestLoginForm() {
   const navigate = useNavigate();
+  const { menu } = useSelector((state) => state.LoginMenuSlice);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const classes = useStyles();
@@ -40,6 +43,7 @@ export default function GuestLoginForm() {
       );
       console.log(data.data.data.name);
       localStorage.setItem("name", data.data.data.name);
+      localStorage.setItem("usertype", menu);
       alert("로그인 성공");
       navigate("/guest/main");
     },

--- a/src/components/map/MapContainer5.jsx
+++ b/src/components/map/MapContainer5.jsx
@@ -20,11 +20,16 @@ export default function MapContainer5() {
   const [markers, setMarkers] = useState([]);
   const [selectedMarker, setSelectedMarker] = useState(null);
   const [target, setTarget] = useState("");
+  const [company, setCompany] = useState({});
+
   const HandlerTargetChange = (e) => {
     setTarget(e.target.value);
   };
 
-  const { data } = useQuery("map", getMap);
+  const { data } = useQuery("map", getMap, {
+    staleTime: Infinity,
+    cacheTime: Infinity,
+  });
   //filter List
   const [searchResults, setSearchResults] = useState(null);
   const handleSearch = async () => {
@@ -35,7 +40,11 @@ export default function MapContainer5() {
       const companyName = e.companyName || "";
       const companyAddress = e.companyAddress || "";
       const companyPhoneNum = e.companyPhoneNum || "";
-      return companyName.includes(target) || companyAddress.includes(target) || companyPhoneNum.includes(target);
+      return (
+        companyName.includes(target) ||
+        companyAddress.includes(target) ||
+        companyPhoneNum.includes(target)
+      );
     });
     setSearchResults(filteredResults);
   };
@@ -52,7 +61,7 @@ export default function MapContainer5() {
           companyName: e.companyName,
           companyAddress: e.companyAddress,
           companyPhoneNum: e.companyPhoneNum,
-        })),
+        }))
       );
     }
   }, [data]);
@@ -82,9 +91,8 @@ export default function MapContainer5() {
     setSelectedMarker(marker);
   };
 
-  console.log(markers);
-
-  const HandlerModalOn = () => {
+  const HandlerModalOn = (e) => {
+    setCompany(e);
     setIsModalOpen(true);
   };
 
@@ -115,7 +123,9 @@ export default function MapContainer5() {
               <DivCompanycontent>{e.companyPhoneNum}</DivCompanycontent>
             </DivListContent>
             <StBtnDiv>
-              <ButtonVisitForm onClick={HandlerModalOn}>방문 신청</ButtonVisitForm>
+              <ButtonVisitForm onClick={() => HandlerModalOn(e)}>
+                방문 신청
+              </ButtonVisitForm>
             </StBtnDiv>
           </DivListBox>
         ))}
@@ -158,16 +168,27 @@ export default function MapContainer5() {
                 <DivMapInfo className="info">
                   <DivMapTitle>
                     {selectedMarker.companyName}
-                    <BtnClose onClick={() => setSelectedMarker(null)} title="닫기" />
+                    <BtnClose
+                      onClick={() => setSelectedMarker(null)}
+                      title="닫기"
+                    />
                   </DivMapTitle>
 
                   <div className="body">
                     <StMapBody>
-                      <div className="ellipsis">{selectedMarker.companyAddress}</div>
-                      <div className="jibun ellipsis">{selectedMarker.companyPhoneNum}</div>
+                      <div className="ellipsis">
+                        {selectedMarker.companyAddress}
+                      </div>
+                      <div className="jibun ellipsis">
+                        {selectedMarker.companyPhoneNum}
+                      </div>
                     </StMapBody>
                     <DivMapButton>
-                      <BtnMapButton onClick={HandlerModalOn}>방문 신청</BtnMapButton>
+                      <BtnMapButton
+                        onClick={() => HandlerModalOn(selectedMarker)}
+                      >
+                        방문 신청
+                      </BtnMapButton>
                     </DivMapButton>
                   </div>
                 </DivMapInfo>
@@ -183,7 +204,14 @@ export default function MapContainer5() {
           onClose={() => {
             setIsModalOpen(false);
           }}
-          children={<ConfirmForm />}
+          children={
+            <ConfirmForm
+              onClose={() => {
+                setIsModalOpen(false);
+              }}
+              company={company}
+            />
+          }
         />
       )}
     </DivMap>

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -1,20 +1,32 @@
 import React from "react";
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+import { useSelector } from "react-redux";
+
 import logo from "../../utils/img/VISITUS_logo.png";
 import logout from "../../utils/img/logout_icon.png";
 import { Link } from "react-router-dom";
 import { removeCookie } from "./../../apis/cookies";
+
 const Navbar = () => {
+  const navigate = useNavigate();
+  const { menu } = useSelector((state) => state.LoginMenuSlice);
+
   const logoutBtn = () => {
     removeCookie("ACCESS_TOKEN");
     localStorage.removeItem("name");
     localStorage.removeItem("REFRESH_TOKEN");
+    localStorage.removeItem("usertype");
+  };
+
+  const HandlerMain = () => {
+    menu === "guest" ? navigate("/guest/main") : navigate("/admin/main");
   };
   return (
     <>
       <StNavBar>
         <StNavbarContainer>
-          <StLogo src={logo} alt="visitus.logo" />
+          <StLogo src={logo} alt="visitus.logo" onClick={HandlerMain} />
           <StUser>
             <StName>{localStorage.getItem("name")}님 반갑습니다</StName>
             <StLogOutContainer>
@@ -50,7 +62,9 @@ const StNavbarContainer = styled.div`
   margin: 0 auto;
 `;
 
-const StLogo = styled.img``;
+const StLogo = styled.img`
+  cursor: pointer;
+`;
 
 const StUser = styled.div`
   display: flex;

--- a/src/pages/ConfirmForm.jsx
+++ b/src/pages/ConfirmForm.jsx
@@ -5,9 +5,9 @@ import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import styled from "styled-components";
 
-const ConfirmForm = ({ onClose }) => {
-  const [location, setLocation] = useState("");
-  const [place, setPlace] = useState("");
+const ConfirmForm = ({ onClose, company }) => {
+  const [location, setLocation] = useState(company.companyName);
+  const [place, setPlace] = useState(company.companyAddress);
   const [target, setTarget] = useState("");
   const [purpose, setPurpose] = useState("");
   const [startDate, setStartDate] = useState("");

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,19 +1,33 @@
-import React, { useState } from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import { Tab, Tabs } from "@mui/material";
 import { useSelector, useDispatch } from "react-redux";
+import { useNavigate } from "react-router-dom";
 
 import GuestLoginForm from "../components/loginForm/GuestLoginForm";
 import AdminLoginForm from "../components/loginForm/AdminLoginForm";
 import mainImg from "../utils/img/background.png";
 import mainLogo from "../utils/img/VISITUS_logo@2x.png";
 import { setMenu } from "../redux/store/LoginMenuSlice";
+import { getCookie } from "../api/cookies";
 
 const Login = () => {
   //로그인 타입 지정
-  const [loginType, setLoginType] = useState("guest");
   const { menu } = useSelector((state) => state.LoginMenuSlice);
   const dispatch = useDispatch();
+
+  //로그인되어있을시 로그인페이지 이동 막고 메인으로 이동 => acc 토큰 여부로 확인
+  const navigate = useNavigate();
+  const isToken = getCookie("ACCESS_TOKEN");
+
+  useEffect(() => {
+    if (isToken) {
+      console.log("여기요;;");
+      const usertype = localStorage.getItem("usertype");
+      usertype === "guest" ? navigate("/guest/main") : navigate("/admin/main");
+    }
+  }, [isToken, navigate]);
+
   const HandleChangeTab = (e, newValue) => {
     console.log(newValue);
     dispatch(setMenu(newValue));


### PR DESCRIPTION
## 기능 설명
1. localstorage를 이용한 로그인 유지 기능구현 => access_token을 확인하여 로그인 여부 판단
2. 방문신청시 해당주소 자동 폼 입력
3. 데이터 캐싱관리 => react-query의 staletime, cahceTime을 이용하여 데이터 캐싱관리
4. refetchOnWindowFocus: false 로 설정하여 포커스시 데이터 재요청 방지